### PR TITLE
feat: Configure GraphQL codegen for Vercel deployment

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: "http://localhost:4000/graphql"
+schema: "${NEXT_PUBLIC_SERVER_BASE_URL}/graphql"
 documents: "graphql/**/*.graphql"
 generates:
   generated/graphql.ts:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "codegen": "graphql-codegen --config codegen.yml"
+    "codegen": "graphql-codegen --config codegen.yml",
+    "vercel:build": "NEXT_PUBLIC_SERVER_BASE_URL=https://main-server-5a55.onrender.com npm run codegen && npm run build"
+
   },
   "dependencies": {
     "@types/lodash.debounce": "^4.0.9",


### PR DESCRIPTION
This commit configures the GraphQL codegen process to work correctly in a Vercel deployment environment.

- Updates the `schema` field in `codegen.yml` to use the `NEXT_PUBLIC_SERVER_BASE_URL` environment variable, allowing the codegen process to target the correct GraphQL endpoint in different environments.
- Adds a `vercel:build` script to `package.json` that sets the `NEXT_PUBLIC_SERVER_BASE_URL` environment variable and runs the `codegen` and `build` scripts. This ensures that the GraphQL code is generated during the Vercel build process.